### PR TITLE
docs: OSS公開に必要な情報を追記(#15)

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 Shimpei Wakida
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,50 @@
+# tui-client
+
+PostgreSQL用TUIクライアント。ターミナルからPostgreSQLデータベースを操作できるTUIアプリケーションです。
+
+[Textual](https://github.com/Textualize/textual) フレームワークで構築されています。
+
+## 機能
+
+- PostgreSQLへの接続管理
+- スキーマ・テーブル一覧のツリー表示
+- テーブルデータの閲覧
+- テーブル名のインクリメンタル検索
+- Vim風キーバインド対応
+
+## インストール
+
+### 前提条件
+
+- Python 3.12以上
+- [uv](https://docs.astral.sh/uv/)
+
+### セットアップ
+
+```bash
+git clone https://github.com/wakidas/tui-client.git
+cd tui-client
+uv sync
+```
+
+## 使い方
+
+```bash
+uv run tui-client
+```
+
+起動すると接続先の選択画面が表示されます。PostgreSQLの接続情報を入力して接続してください。
+
+## 開発
+
+```bash
+# 依存関係のインストール（開発用含む）
+uv sync
+
+# テストの実行
+uv run pytest
+```
+
+## ライセンス
+
+[MIT License](LICENSE)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,12 +1,21 @@
 [project]
 name = "tui-client"
 version = "0.1.0"
-description = "Add your description here"
+description = "PostgreSQL用TUIクライアント"
 readme = "README.md"
+license = { text = "MIT" }
 authors = [
     { name = "Shimpei Wakida", email = "shimpei.wakida@gmail.com" }
 ]
 requires-python = ">=3.12"
+classifiers = [
+    "License :: OSI Approved :: MIT License",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.12",
+]
+
+[project.urls]
+Repository = "https://github.com/wakidas/tui-client"
 
 dependencies = [
     "psycopg[binary]>=3.3.3",


### PR DESCRIPTION
## Summary

Closes #15

OSSとして公開するために必要な情報を追記しました。

- **LICENSE**: MITライセンスファイルを新規作成
- **README.md**: プロジェクト概要、機能一覧、インストール方法、使い方、開発方法、ライセンス情報を記載
- **pyproject.toml**: description、license、classifiers、repository URLを追加

## Test plan

- [x] `uv sync` が正常に動作すること
- [x] `uv run tui-client` が正常に起動すること
- [ ] GitHubリポジトリページでLICENSEとREADMEが正しく表示されること